### PR TITLE
add full response body to ruby_outlook_response result key

### DIFF
--- a/lib/ruby_outlook.rb
+++ b/lib/ruby_outlook.rb
@@ -78,7 +78,10 @@ module RubyOutlook
       end
 
       if response.status >= 300
-        return JSON.dump({ 'ruby_outlook_error' => response.status})
+        error_info = response.body.empty? ? '' : JSON.parse(response.body)
+        return JSON.dump({ 
+          'ruby_outlook_error' => response.status,
+          'ruby_outlook_response' => error_info })
       end
 
       response.body


### PR DESCRIPTION
Hi Jason,
Thanks for maintaining this gem. We found it very useful to interact with our enterprise outlook server and it was a real time saver!

One issue we observed was the lack of info in the response body especially when errors occur. We only get the response body but it's hard to troubleshoot it.

This PR adds the full response body to the returned JSON in a new key called `ruby_outlook_response`. I tried to pretty much follow the existing naming convention.

Any feedback is very much appreciated.

Thank you.
Fabio