### PR TITLE
Replace the default payload with an empty object for custom api calls

### DIFF
--- a/lib/ruby_outlook.rb
+++ b/lib/ruby_outlook.rb
@@ -26,7 +26,7 @@ module RubyOutlook
     # params (hash) a Ruby hash containing any query parameters needed for the API call
     # payload (hash): a JSON hash representing the API call's payload. Only used
     #                 for POST or PATCH.
-    def make_api_call(method, url, token, params = nil, payload = nil)
+    def make_api_call(method, url, token, params = nil, payload = {})
 
       conn_params = {
         :url => 'https://outlook.office365.com'


### PR DESCRIPTION
Problem: Using this `make_api_call` [method](https://github.com/jasonjoh/ruby_outlook/blob/master/lib/ruby_outlook.rb#L29) for this [endpoint](https://msdn.microsoft.com/en-us/office/office365/api/mail-rest-operations#SendMessages)`POST https://outlook.office.com/api/v2.0/me/messages/{message_id}/send` returns the below error. 
```
"{\"ruby_outlook_error\":400,\"ruby_outlook_response\":{\"error\":{\"code\":\"RequestBodyRead\",\"message\":\"An unexpected 'PrimitiveValue' node was found when reading from the JSON reader. A 'StartObject' node was expected.\"}}}"
```
Solution: Replace the primitive value in the event that one is not necessary with an empty hash. 