### PR TITLE
Update get_calendar_view to get more details

### DIFF
--- a/lib/ruby_outlook.rb
+++ b/lib/ruby_outlook.rb
@@ -377,8 +377,8 @@ module RubyOutlook
       request_url << "/CalendarView"
 
       request_params = {
-        'startDateTime' => window_start.strftime('%Y-%m-%dT00:00:00Z'),
-        'endDateTime' => window_end.strftime('%Y-%m-%dT00:00:00Z')
+        'startDateTime' => window_start.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'endDateTime' => window_end.strftime('%Y-%m-%dT%H:%M:%SZ')
       }
 
       unless fields.nil?

--- a/lib/ruby_outlook/version.rb
+++ b/lib/ruby_outlook/version.rb
@@ -1,3 +1,3 @@
 module RubyOutlook
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
I'd like to get calendars more precisely with `get_calendars_view` by using hours, minutes and seconds parameters.

For example, currently,

```
>calendars = @client.get_calendar_view(@access_token, DateTime.parse('2017-07-15T00:00:00'), DateTime.parse('2017-07-15T05:00:00'))
> calendars['value'].map{|c| [c['Start']['DateTime'], c['End']['DateTime']]}
=> [["2017-07-15T00:00:00.0000000", "2017-07-15T01:00:00.0000000"]]
```

I'd like to do that.

```
>calendars = @client.get_calendar_view(@access_token, DateTime.parse('2017-07-15T00:00:00'), DateTime.parse('2017-07-15T05:00:00'))
> calendars['value'].map{|c| [c['Start']['DateTime'], c['End']['DateTime']]}
=> [["2017-07-15T00:00:00.0000000", "2017-07-15T01:00:00.0000000"],
 ["2017-07-15T02:00:00.0000000", "2017-07-15T06:00:00.0000000"]]
```

Please review it.
